### PR TITLE
Fix: correctly identifying when the default font is used

### DIFF
--- a/whatfont.js
+++ b/whatfont.js
@@ -196,12 +196,13 @@
 
     for (i = 0; i < fonts.length; i += 1) {
       a1 = mkTextPixelArray(fonts[i]);
-      if (sameArray(a0, a1)) {
+      if (sameArray(a0, a1)
+          && sameArray(mkTextPixelArray(fonts[i] + ',serif'), mkTextPixelArray(fonts[i] + ',sans-serif'))) {
+        // rendered fonts match, and font really is installed
         return fonts[i].replace(/^\s*/, "").replace(/\s*$/, "");
       }
     }
-    
-    return '(fallback)';  // no match; use fallback font
+    return "default";
   }
   
   function firstFont(cssfontfamily) {
@@ -279,10 +280,11 @@
   }
   
   function getPanelFontFamily(elem) {
-    var ff, fiu, font, fHTML;
+    var ff, fiu, fiuFound, font, fHTML;
     
     ff = getCSSProperty(elem, 'font-family').split(',');
     fiu = getFontInUse(elem);
+    fiuFound = false;
     for (font = 0; font < ff.length; font += 1) {
       ff[font] = ff[font].replace(/^\s*/, "").replace(/\s*$/, "").replace(/;$/, "");
     }
@@ -292,11 +294,15 @@
         ff[font] = "<span class='" + getClassName("fniu") + "'>" + ff[font] + "</span>";
       } else {
         ff[font] = "<span class='" + getClassName("fiu") + "'>" + ff[font] + "</span>";
+        fiuFound = true;
         break;
       }
     }
     
     fHTML = ff.join(", ") + ";";
+    if (!fiuFound) {
+      fHTML += " (<span class='" + getClassName("fiu") + "'>" + fiu + "</span>)";
+    }
     
     return [createElem('dt', 'family', "Font Family"), createElem('dd', '', fHTML)];
   }


### PR DESCRIPTION
WhatFont is awesome -- I have been looking for something like this for ages. Here's a patch to fix an issue I have found.

If the font family contains only fonts that aren't installed, then WhatFont reports that the rendered font is the first one in the list. It should report that the default font is used. I made a test page at
http://www.thunderguy.com/public/whatfont-test.html
that shows the issue.

My change does the following: If a single font matches the font stack, then check whether the rendered font is really installed. This is necessary because if none of the fonts in the stack are installed then the rendered font will always be the browser's default font, so it will match the font stack even though the font is not installed.
