### PR TITLE
Add Fontdeck detection support

### DIFF
--- a/whatfont_core.js
+++ b/whatfont_core.js
@@ -275,7 +275,6 @@ function _whatFont() {
 			$.each(projectIds, function(i, projectId){
 				$.getJSON("http://fontdeck.com/api/v1/project-info?project=" + projectId + "&domain=" + domain + "&callback=?", function (data) {
 					if( typeof data !== 'undefined' && typeof data.provides !== 'undefined' ) {
-						console.log(data);
 						$.each(data.provides, function (i, font) {
 							var fontName = font.name,
 								slug = fontName.replace(/ /g, '-').toLowerCase(),


### PR DESCRIPTION
Hello!

I've done a bit of work on the core js file to add detection of fonts served from fontdeck.com. It uses the (as yet undocumented) Fontdeck api to retrieve the font details.

Just as a note: In order to get the link to the font on the Fontdeck website, it checks if the API has supplied a URL for that font, otherwise it falls back to submitting a search with that font's name. The search fallback is really just a stopgap solution as the API does not yet supply the URL for all fonts yet, but it will do shortly.

Hope this is useful for you - any questions or amends please let me know.

Mark
