### PR TITLE
Changed CSS URL to HTTPS rawgit URL

### DIFF
--- a/src/js/whatfont_core.js
+++ b/src/js/whatfont_core.js
@@ -199,7 +199,7 @@ function _whatFont() {
 
 	css = {
 		STYLE_PRE: '__whatfont_',
-		CSS_URL: "http://chengyinliu.com/wf.css?ver=" + VER,
+		CSS_URL: "https://cdn.rawgit.com/chengyin/WhatFont-Bookmarklet/master/src/css/whatfont.css?ver=" + VER,
 		LINK: null,
 
 		init: function() {


### PR DESCRIPTION
Bookmarklet has to load from HTTPS otherwise it won’t load on some HTTPS sites. The URL in the bookmarklet itself has to be changed to https://cdn.rawgit.com/chengyin/WhatFont-Bookmarklet/master/src/js/whatfont_core.js as well.
